### PR TITLE
Update ad.user.js

### DIFF
--- a/ad.user.js
+++ b/ad.user.js
@@ -10,10 +10,15 @@
 // @run-at       document-start
 // ==/UserScript==
 
+Object.defineProperty(document, 'visibilityState', {value: 'visible', writable: true});
+Object.defineProperty(document, 'hidden', {value: false, writable: true});
+Object.defineProperty(document, 'webkitVisibilityState', {value: 'visible', writable: true});
+Object.defineProperty(document, 'webkitHidden', {value: false, writable: true});
+
 Window.prototype.realEventListener = Window.prototype.addEventListener
 Window.prototype.addEventListener = (a,b,c) =>
 {
-    if(a == 'focus' || a == 'blur')
+    if(a == 'focus' || a == 'blur' || a == 'visibilitychange')
         console.log(`[AD] '${a}' event subscription prevented.`)
     else
         realEventListener(a,b,c);


### PR DESCRIPTION
The document's 'hidden' and 'visibilityState' properties could be checked (i.e. with a setInterval), so it is needed to be overwritten as 'visible' and 'hidden = false'.
Also, visibilityChange event can be listened, so it is removed, like the blur and focus event

I added these changes, because who knows, when does canvas changes its mind updates its methods of checking
(I do not know the exact way canvas checks this)